### PR TITLE
wrap the collection load process with a try catch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules/
 npm-debug.log
+test/testdb/

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ This will check for a directory at given path, if it does not exits, diskDB will
 
 If the directory exists but the file/collection does not exist, diskDB will create it for you.
 
-**Note** : If you have manually created an empty JSON file, please make sure that it contains at least an empty array.
+**Note** : If you have manually created a JSON file, please make sure it contains a valid JSON array, otherwise diskDB
+will return an empty array.
 
 ```js
 []

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -15,8 +15,17 @@ module.exports = function(db, collectionName) {
     coltn.collectionName = collectionName;
     coltn._f = path.join(db._db.path, (collectionName + '.json'));
 
+    coltn._parse = function() {
+        try {
+          return JSON.parse(String(util.readFromFile(this._f)))
+        } catch (err) {
+          console.error('Invalid JSON', err);
+        }
+        return []
+    };
+
     coltn.find = function(query) {
-        var collection = JSON.parse(util.readFromFile(this._f));
+        var collection = this._parse();
         if (!query || Object.keys(query).length === 0) {
             return collection;
         } else {
@@ -26,7 +35,7 @@ module.exports = function(db, collectionName) {
     };
 
     coltn.findOne = function(query) {
-        var collection = JSON.parse(util.readFromFile(this._f));
+        var collection = this._parse();
         if (!query) {
             return collection[0];
         } else {
@@ -36,7 +45,7 @@ module.exports = function(db, collectionName) {
     };
 
     coltn.save = function(data) {
-        var collection = JSON.parse(util.readFromFile(this._f));
+        var collection = this._parse();
         if (typeof data === 'object' && data.length) {
             if (data.length === 1) {
                 if (data[0].length > 0) {
@@ -62,7 +71,7 @@ module.exports = function(db, collectionName) {
 
     coltn.update = function(query, data, options) {
         var ret = {},
-            collection = JSON.parse(util.readFromFile(this._f)); // update
+            collection = this._parse(); // update
         var records = util.finder(collection, query, true);
         if (records.length) {
             if (options && options.multi) {
@@ -91,7 +100,7 @@ module.exports = function(db, collectionName) {
 
     coltn.remove = function(query, multi) {
         if (query) {
-            var collection = JSON.parse(util.readFromFile(this._f));
+            var collection = this._parse();
             if (typeof multi === 'undefined') {
                 multi = true;
             }
@@ -106,7 +115,7 @@ module.exports = function(db, collectionName) {
     };
 
     coltn.count = function() {
-        return (JSON.parse(util.readFromFile(this._f))).length;
+        return this._parse().length;
     };
 
     return coltn;

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -10,18 +10,26 @@ var util = require('./util'),
     path = require('path'),
     uuid = require('node-uuid');
 
-module.exports = function(db, collectionName) {
+module.exports = function(db, collectionName, opts) {
+
+    opts = opts || {};
+
+    // throw an exception if the collection's JSON file is invalid?
+    opts.throwParseError = opts.throwParseError === undefined ? false : opts.throwParseError;
+
     var coltn = {};
     coltn.collectionName = collectionName;
     coltn._f = path.join(db._db.path, (collectionName + '.json'));
 
     coltn._parse = function() {
         try {
-          return JSON.parse(String(util.readFromFile(this._f)))
+            return JSON.parse(String(util.readFromFile(this._f)));
         } catch (err) {
-          console.error('Invalid JSON', err);
+            if (opts.throwParseError) {
+                throw err;
+            }
         }
-        return []
+        return [];
     };
 
     coltn.find = function(query) {
@@ -29,7 +37,7 @@ module.exports = function(db, collectionName) {
         if (!query || Object.keys(query).length === 0) {
             return collection;
         } else {
-            var searcher = new util.ObjectSearcher(); 
+            var searcher = new util.ObjectSearcher();
             return searcher.findAllInObject(collection, query, true);
         }
     };
@@ -39,7 +47,7 @@ module.exports = function(db, collectionName) {
         if (!query) {
             return collection[0];
         } else {
-            var searcher = new util.ObjectSearcher(); 
+            var searcher = new util.ObjectSearcher();
             return searcher.findAllInObject(collection, query, false)[0];
         }
     };

--- a/test/diskdb_test.js
+++ b/test/diskdb_test.js
@@ -127,7 +127,7 @@ exports.connectNload = {
         test.expect(1);
         // connect to DB
         diskdb.connect(dbPath);
-        // we manually create the file with an empty content
+        // we manually create the file with an empty and/or invalid JSON content
         fs.writeFileSync(path.join(dbPath, 'articles.json'), 'empty string or invalid json');
         // we don't have an exception anymore...
         test.deepEqual(diskdb.articles.find(), []);

--- a/test/diskdb_test.js
+++ b/test/diskdb_test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var diskdb = require('../lib/diskdb.js');
+var path = require('path');
 var fs = require('fs');
 
 /*
@@ -120,6 +121,16 @@ exports.connectNload = {
         //load multiple collections
         test.equal(diskdb.loadCollections(collections)[collections[0]].collectionName, collections[0], 'Loading multiple collection');
         test.equal(diskdb.loadCollections(collections)[collections[1]].collectionName, collections[1], 'Loading multiple collection');
+        test.done();
+    },
+    'loadCollectionsWhenFileIsEmpty : ': function(test) {
+        test.expect(1);
+        // connect to DB
+        diskdb.connect(dbPath);
+        // we manually create the file with an empty content
+        fs.writeFileSync(path.join(dbPath, 'articles.json'), 'empty string or invalid json');
+        // we don't have an exception anymore...
+        test.deepEqual(diskdb.articles.find(), []);
         test.done();
     },
     tearDown: function(callback) {

--- a/test/diskdb_test.js
+++ b/test/diskdb_test.js
@@ -123,7 +123,7 @@ exports.connectNload = {
         test.equal(diskdb.loadCollections(collections)[collections[1]].collectionName, collections[1], 'Loading multiple collection');
         test.done();
     },
-    'loadCollectionsWhenFileIsEmpty : ': function(test) {
+    'loadCollectionsWhenFileIsInvalid : ': function(test) {
         test.expect(1);
         // connect to DB
         diskdb.connect(dbPath);


### PR DESCRIPTION
First of all, sorry for my english :)
One of my colleague had an error every time she tried to save something in a collection.
First, we didn't understand why because the object she tried to save was good and we saw that the file exists. 
We found after some minutes that the json file was empty. So the collection parse process broke every time. Its seems that the first time she tried to save (the first object in the collection), there was an error, but the file was created and remained empty.
This kind of error will happen only the first time the collection is created, so just returning an empty array in this case will fix the problem.
I don't considerate the cases where you try to save an invalid thing because you already though about it and the file will not be corrupted.
So, I make the PR, it's on your hand now.